### PR TITLE
remove static namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,30 +97,7 @@ export default {
          * in the `window.paypal` namespace.
          */
 
-        entry: './src/index',
-
-        /**
-         * Define a static namespace.
-         * Server config will be available under the `__lebowski_pay__.serverConfig` global
-         */
-
-        staticNamespace: '__lebowski_pay__',
-
-        /**
-         * Define configuration required by this module
-         *
-         * - This should be in the form of a graphql query.
-         * - The query will be merged with queries defined by other modules
-         * - The final config will be passed as `__lebowski_pay__.serverConfig` in `./src/index`
-         */
-
-        configQuery: `
-            fundingEligibility {
-                card {
-                    branded
-                }
-            }
-        `
+        entry: './src/index'
     }
 };
 ```

--- a/__sdk__.js
+++ b/__sdk__.js
@@ -2,8 +2,7 @@
 /* eslint import/no-commonjs: 0 */
 
 module.exports = {
-
     'example-pay': {
-        entry: './src/component',
+        entry: './src/component'
     }
 };

--- a/__sdk__.js
+++ b/__sdk__.js
@@ -5,7 +5,5 @@ module.exports = {
 
     'example-pay': {
         entry: './src/component',
-        
-        staticNamespace: '__example_pay__'
     }
 };


### PR DESCRIPTION
we removed the ability to set static namespaces from clientsdknodeweb last year, cleaning up stragglers 